### PR TITLE
perf: use JAX for 2x speedup with transform and sum operations

### DIFF
--- a/analysis/workflow/scripts/aou/manual_touch.bash
+++ b/analysis/workflow/scripts/aou/manual_touch.bash
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-LOG_FILE="${1:log}"
+LOG_FILE="${1:-log}"
 WORKDIR="${WORKDIR:-/tmp/snakemake_gcs_touch}"
 mkdir -p "$WORKDIR"
 

--- a/analysis/workflow/scripts/aou/manual_touch.bash
+++ b/analysis/workflow/scripts/aou/manual_touch.bash
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+# Touch all files in a dry-run of Snakemake
+
+set -euo pipefail
+
+LOG_FILE="${1:log}"
+WORKDIR="${WORKDIR:-/tmp/snakemake_gcs_touch}"
+mkdir -p "$WORKDIR"
+
+DRY_RUN="${DRY_RUN:-0}"  # DRY_RUN=1 to only print actions
+
+need_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "Missing required command: $1" >&2; exit 1; }; }
+need_cmd gcloud
+need_cmd awk
+need_cmd sed
+need_cmd mktemp
+need_cmd grep
+
+# Extract gs:// URIs from output: blocks, in appearance order, and de-dupe while preserving order.
+mapfile -t GCS_URIS < <(
+  awk '
+    BEGIN {inout=0}
+    /^    output:/ {inout=1; sub(/^    output:[[:space:]]*/, ""); print; next}
+    inout==1 {
+      if ($0 ~ /^    /) { sub(/^    /,""); print; next }
+      inout=0
+    }
+  ' "$LOG_FILE" \
+  | tr ',' '\n' \
+  | sed -E 's/\(send to storage\)//g; s/\(retrieve from storage\)//g; s/^[[:space:]]+//; s/[[:space:]]+$//' \
+  | awk '
+      /^gs:\/\// {
+        if (!seen[$0]++) print $0
+      }
+    '
+)
+
+if [[ ${#GCS_URIS[@]} -eq 0 ]]; then
+  echo "No gs:// URIs found in output: blocks in $LOG_FILE" >&2
+  exit 2
+fi
+
+echo "Found ${#GCS_URIS[@]} unique output objects (order preserved)."
+echo "Workdir: $WORKDIR"
+echo "Dry-run: $DRY_RUN"
+echo
+
+touch_one() {
+  local uri="$1"
+
+  # Existence check (skip missing; also skip prefix-style matches)
+  local ls_out=""
+  ls_out="$(gcloud storage ls "$uri" 2>/dev/null || true)"
+
+  if [[ -z "$ls_out" ]]; then
+    echo "[SKIP missing] $uri"
+    return 0
+  fi
+  if ! grep -Fxq -- "$uri" <<<"$ls_out"; then
+    echo "[SKIP non-object/prefix] $uri"
+    return 0
+  fi
+
+  local tmpdir localpath
+  tmpdir="$(mktemp -d "$WORKDIR/touch.XXXXXX")"
+  localpath="$tmpdir/object"
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "[DRY] gcloud storage cp '$uri' '$localpath'"
+    echo "[DRY] gcloud storage cp '$localpath' '$uri'"
+  else
+    gcloud storage cp "$uri" "$localpath"
+    gcloud storage cp "$localpath" "$uri"
+  fi
+
+  rm -rf "$tmpdir"
+  echo "[OK] touched $uri"
+}
+
+# Sequential, in-order processing:
+for uri in "${GCS_URIS[@]}"; do
+  touch_one "$uri"
+done
+
+echo
+echo "Done."

--- a/analysis/workflow/scripts/aou/manual_touch.bash
+++ b/analysis/workflow/scripts/aou/manual_touch.bash
@@ -20,25 +20,23 @@ for uri in $(grep 'output:' "$LOG_FILE" | sed 's/^.*output: //' | sed 's/, /\n/g
     ls_out="$(gcloud storage ls "$uri" 2>/dev/null || true)"
 
     if [[ -z "$ls_out" ]]; then
-        echo "[SKIP missing] $uri"
+        echo "[SKIP missing] $uri" >&2
         return 0
     fi
     if ! grep -Fxq -- "$uri" <<<"$ls_out"; then
-        echo "[SKIP non-object/prefix] $uri"
+        echo "[SKIP non-object/prefix] $uri" >&2
         return 0
     fi
 
     localpath="$tmpdir/object"
 
     if [[ "$DRY_RUN" == "1" ]]; then
-        echo "[DRY] gcloud storage cp '$uri' '$localpath'"
-        echo "[DRY] gcloud storage cp '$localpath' '$uri'"
+        echo "gcloud storage cp '$uri' '$localpath'"
+        echo "gcloud storage cp '$localpath' '$uri'"
     else
         gcloud storage cp "$uri" "$localpath"
         gcloud storage cp "$localpath" "$uri"
     fi
-
-    echo "[OK] touched $uri"
 
 done
 

--- a/analysis/workflow/scripts/aou/manual_touch.bash
+++ b/analysis/workflow/scripts/aou/manual_touch.bash
@@ -10,77 +10,37 @@ mkdir -p "$WORKDIR"
 
 DRY_RUN="${DRY_RUN:-0}"  # DRY_RUN=1 to only print actions
 
-need_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "Missing required command: $1" >&2; exit 1; }; }
-need_cmd gcloud
-need_cmd awk
-need_cmd sed
-need_cmd mktemp
-need_cmd grep
-
 # Extract gs:// URIs from output: blocks, in appearance order, and de-dupe while preserving order.
-mapfile -t GCS_URIS < <(
-  awk '
-    BEGIN {inout=0}
-    /^    output:/ {inout=1; sub(/^    output:[[:space:]]*/, ""); print; next}
-    inout==1 {
-      if ($0 ~ /^    /) { sub(/^    /,""); print; next }
-      inout=0
-    }
-  ' "$LOG_FILE" \
-  | tr ',' '\n' \
-  | sed -E 's/\(send to storage\)//g; s/\(retrieve from storage\)//g; s/^[[:space:]]+//; s/[[:space:]]+$//' \
-  | awk '
-      /^gs:\/\// {
-        if (!seen[$0]++) print $0
-      }
-    '
-)
+for uri in $(grep 'output:' log | sed 's/^.*output: //' | sed 's/, /\n/g;s/ (.* storage)//g')); do
 
-if [[ ${#GCS_URIS[@]} -eq 0 ]]; then
-  echo "No gs:// URIs found in output: blocks in $LOG_FILE" >&2
-  exit 2
-fi
+    # Existence check (skip missing; also skip prefix-style matches)
+    local ls_out=""
+    ls_out="$(gcloud storage ls "$uri" 2>/dev/null || true)"
 
-echo "Found ${#GCS_URIS[@]} unique output objects (order preserved)."
-echo "Workdir: $WORKDIR"
-echo "Dry-run: $DRY_RUN"
-echo
+    if [[ -z "$ls_out" ]]; then
+        echo "[SKIP missing] $uri"
+        return 0
+    fi
+    if ! grep -Fxq -- "$uri" <<<"$ls_out"; then
+        echo "[SKIP non-object/prefix] $uri"
+        return 0
+    fi
 
-touch_one() {
-  local uri="$1"
+    local tmpdir localpath
+    tmpdir="$(mktemp -d "$WORKDIR/touch.XXXXXX")"
+    localpath="$tmpdir/object"
 
-  # Existence check (skip missing; also skip prefix-style matches)
-  local ls_out=""
-  ls_out="$(gcloud storage ls "$uri" 2>/dev/null || true)"
+    if [[ "$DRY_RUN" == "1" ]]; then
+        echo "[DRY] gcloud storage cp '$uri' '$localpath'"
+        echo "[DRY] gcloud storage cp '$localpath' '$uri'"
+    else
+        gcloud storage cp "$uri" "$localpath"
+        gcloud storage cp "$localpath" "$uri"
+    fi
 
-  if [[ -z "$ls_out" ]]; then
-    echo "[SKIP missing] $uri"
-    return 0
-  fi
-  if ! grep -Fxq -- "$uri" <<<"$ls_out"; then
-    echo "[SKIP non-object/prefix] $uri"
-    return 0
-  fi
+    rm -rf "$tmpdir"
+    echo "[OK] touched $uri"
 
-  local tmpdir localpath
-  tmpdir="$(mktemp -d "$WORKDIR/touch.XXXXXX")"
-  localpath="$tmpdir/object"
-
-  if [[ "$DRY_RUN" == "1" ]]; then
-    echo "[DRY] gcloud storage cp '$uri' '$localpath'"
-    echo "[DRY] gcloud storage cp '$localpath' '$uri'"
-  else
-    gcloud storage cp "$uri" "$localpath"
-    gcloud storage cp "$localpath" "$uri"
-  fi
-
-  rm -rf "$tmpdir"
-  echo "[OK] touched $uri"
-}
-
-# Sequential, in-order processing:
-for uri in "${GCS_URIS[@]}"; do
-  touch_one "$uri"
 done
 
 echo

--- a/analysis/workflow/scripts/aou/manual_touch.bash
+++ b/analysis/workflow/scripts/aou/manual_touch.bash
@@ -10,11 +10,13 @@ mkdir -p "$WORKDIR"
 
 DRY_RUN="${DRY_RUN:-0}"  # DRY_RUN=1 to only print actions
 
+tmpdir="$(mktemp -d "$WORKDIR/touch.XXXXXX")"
+
 # Extract gs:// URIs from output: blocks, in appearance order, and de-dupe while preserving order.
 for uri in $(grep 'output:' "$LOG_FILE" | sed 's/^.*output: //' | sed 's/, /\n/g;s/ (.* storage)//g'); do
 
     # Existence check (skip missing; also skip prefix-style matches)
-    local ls_out=""
+    ls_out=""
     ls_out="$(gcloud storage ls "$uri" 2>/dev/null || true)"
 
     if [[ -z "$ls_out" ]]; then
@@ -26,8 +28,6 @@ for uri in $(grep 'output:' "$LOG_FILE" | sed 's/^.*output: //' | sed 's/, /\n/g
         return 0
     fi
 
-    local tmpdir localpath
-    tmpdir="$(mktemp -d "$WORKDIR/touch.XXXXXX")"
     localpath="$tmpdir/object"
 
     if [[ "$DRY_RUN" == "1" ]]; then
@@ -38,10 +38,10 @@ for uri in $(grep 'output:' "$LOG_FILE" | sed 's/^.*output: //' | sed 's/, /\n/g
         gcloud storage cp "$localpath" "$uri"
     fi
 
-    rm -rf "$tmpdir"
     echo "[OK] touched $uri"
 
 done
 
-echo
+rm -rf "$tmpdir"
+
 echo "Done."

--- a/analysis/workflow/scripts/aou/manual_touch.bash
+++ b/analysis/workflow/scripts/aou/manual_touch.bash
@@ -11,7 +11,7 @@ mkdir -p "$WORKDIR"
 DRY_RUN="${DRY_RUN:-0}"  # DRY_RUN=1 to only print actions
 
 # Extract gs:// URIs from output: blocks, in appearance order, and de-dupe while preserving order.
-for uri in $(grep 'output:' log | sed 's/^.*output: //' | sed 's/, /\n/g;s/ (.* storage)//g')); do
+for uri in $(grep 'output:' "$LOG_FILE" | sed 's/^.*output: //' | sed 's/, /\n/g;s/ (.* storage)//g'); do
 
     # Existence check (skip missing; also skip prefix-style matches)
     local ls_out=""

--- a/analysis/workflow/scripts/aou/manual_touch.bash
+++ b/analysis/workflow/scripts/aou/manual_touch.bash
@@ -12,8 +12,8 @@ DRY_RUN="${DRY_RUN:-0}"  # DRY_RUN=1 to only print actions
 
 tmpdir="$(mktemp -d "$WORKDIR/touch.XXXXXX")"
 
-# Extract gs:// URIs from output: blocks, in appearance order, and de-dupe while preserving order.
-for uri in $(grep 'output:' "$LOG_FILE" | sed 's/^.*output: //' | sed 's/, /\n/g;s/ (.* storage)//g'); do
+# Extract gs:// URIs from output: blocks in appearance order
+for uri in $(grep 'output:' "$LOG_FILE" | sed 's/^.*output: //' | sed 's/, /\n/g;s/ \(.* storage\)//g'); do
 
     # Existence check (skip missing; also skip prefix-style matches)
     ls_out=""
@@ -21,11 +21,11 @@ for uri in $(grep 'output:' "$LOG_FILE" | sed 's/^.*output: //' | sed 's/, /\n/g
 
     if [[ -z "$ls_out" ]]; then
         echo "[SKIP missing] $uri" >&2
-        return 0
+        continue
     fi
     if ! grep -Fxq -- "$uri" <<<"$ls_out"; then
         echo "[SKIP non-object/prefix] $uri" >&2
-        return 0
+        continue
     fi
 
     localpath="$tmpdir/object"

--- a/analysis/workflow/scripts/aou/manual_touch.bash
+++ b/analysis/workflow/scripts/aou/manual_touch.bash
@@ -13,7 +13,7 @@ DRY_RUN="${DRY_RUN:-0}"  # DRY_RUN=1 to only print actions
 tmpdir="$(mktemp -d "$WORKDIR/touch.XXXXXX")"
 
 # Extract gs:// URIs from output: blocks in appearance order
-for uri in $(grep 'output:' "$LOG_FILE" | sed 's/^.*output: //' | sed 's/, /\n/g;s/ \(.* storage\)//g'); do
+for uri in $(grep 'output:' "$LOG_FILE" | sed 's/^.*output: //' | sed 's/, /\n/g;s/ (.* storage)//g'); do
 
     # Existence check (skip missing; also skip prefix-style matches)
     ls_out=""

--- a/analysis/workflow/scripts/geuvadis_plots.bash
+++ b/analysis/workflow/scripts/geuvadis_plots.bash
@@ -167,7 +167,7 @@ EOF
     echo -ne "region\tgene\thap.id\tpip\t"
     head -n1 data/geuvadis/mlamkin/Geuvadis_varlevel_corrected_significant_variants.with-end.tsv && \
     ~/miniconda3/envs/htslib/bin/bedtools intersect -a <(
-      echo -e "chrom\tstart\tend\tgene\tpip" && cat "$out"/pips.tsv | sed 's+_+\t+;s+-+\t+;s+:+\t+g' | sort -k1,1V -k2,2n
+      echo -e "chrom\tstart\tend\tgene\thap.id\tpip" && tail -n+2 "$out"/pips.tsv | sed 's+_+\t+;s+-+\t+;s+:+\t+g' | sort -k1,1V -k2,2n
     ) -b data/geuvadis/mlamkin/Geuvadis_varlevel_corrected_significant_variants.with-end.tsv -wa -wb -loj | \
     sed 's+\t+_+;s+\t+-+'
   ) | awk -F'\t' '$2 == $8' | cut -f8 --complement > "$out"/STR_assocations.tsv
@@ -267,10 +267,12 @@ EOF
 echo "Created $out/bench.png" 1>&2
 
 # merge all of the .tsv files together
-join -t $'\t' -j1 --header <(
+(
   echo -e "locus\thap_pip\tbest_snp_pip"
   join -t $'\t' -j1 <(tail -n+2 pips.tsv | sed 's/:/\t/g' | sed 's/\t/:/' | sort -k1,1) <(tail -n+2 exclude_pips.tsv | sort -k1,1) | sed 's/\t/:/' | sort -k1,1
-) <(
+) > merged_pips.tsv
+
+join -t $'\t' -j1 --header merged_pips.tsv <(
   head -n1 variance_explained.tsv
   tail -n+2 variance_explained.tsv | sort -k1,1
 ) | sort -k1,1 | (

--- a/happler/tree/assoc_test.py
+++ b/happler/tree/assoc_test.py
@@ -505,12 +505,8 @@ class AssocTestSimpleFastBIC(AssocTestSimpleSM):
         npt.NDArray[np.float64]
             The BIC values from testing this chunk of haplotypes, with shape (p,)
         """
-        use_jax = False
-        if use_jax:
-            # Call JAX JIT-compiled helper and convert result to writable NumPy array
-            return np.array(_compute_bic_jit(X, yc), copy=True)
-        else:
-            return self._compute_bic(X, yc)
+        return np.array(_compute_bic_jit(X, yc), copy=True)
+        # return self._compute_bic(X, yc)
 
     def run(self, X: npt.NDArray[np.float64], y: npt.NDArray[np.float64]) -> AssocResults:
         """

--- a/happler/tree/assoc_test.py
+++ b/happler/tree/assoc_test.py
@@ -454,7 +454,9 @@ class AssocTestSimpleFastBIC(AssocTestSimpleSM):
         self.results_type = NodeResultsBIC
         self.chunk_size = chunk_size
 
-    def _compute_bic(X: npt.NDArray[np.float64], yc: npt.NDArray[np.float64]) -> npt.NDArray:
+    def _compute_bic(
+        self, X: npt.NDArray[np.float64], yc: npt.NDArray[np.float64]
+    ) -> npt.NDArray:
         n = X.shape[0]
         nobs2 = n / 2.0
         log2pi = np.log(2 * np.pi)

--- a/happler/tree/assoc_test.py
+++ b/happler/tree/assoc_test.py
@@ -454,6 +454,33 @@ class AssocTestSimpleFastBIC(AssocTestSimpleSM):
         self.results_type = NodeResultsBIC
         self.chunk_size = chunk_size
 
+    def _compute_bic(X: npt.NDArray[np.float64], yc: npt.NDArray[np.float64]) -> npt.NDArray:
+        n = X.shape[0]
+        nobs2 = n / 2.0
+        log2pi = np.log(2 * np.pi)
+
+        # Center X and y
+        xc = X - X.mean(axis=0)  # (n, p)
+
+        # Vectorized simple OLS with intercept
+        sxx = np.sum(xc**2, axis=0)  # (p,)
+        sxy = np.sum(xc * yc, axis=0)  # (p,)
+
+        with np.errstate(divide="ignore", invalid="ignore"):
+            b1 = np.where(sxx > 0, sxy / sxx, 0.0)  # slopes, (p,)
+
+        # Residuals for each column's model: r = (y - ym) - b1 * (X - xm)
+        syy = float(np.sum(yc**2))  # scalar
+        ssr = syy - 2 * b1 * sxy + (b1**2) * sxx
+
+        # statsmodels-style profile log-likelihood per column
+        # ll = -n/2 * [ log(2π) + log(SSR/n) + 1 ]
+        with np.errstate(divide="ignore"):
+            ll = -nobs2 * (log2pi + np.log(ssr / n) + 1.0)  # (p,)
+
+        # Number of parameters k: intercept + slope = 2
+        return -2 * ll + 2 * np.log(n)  # (p,)
+
     def perform_test(
         self, X: npt.NDArray[np.float64], yc: npt.NDArray[np.float64]
     ) -> npt.NDArray:
@@ -476,9 +503,12 @@ class AssocTestSimpleFastBIC(AssocTestSimpleSM):
         npt.NDArray[np.float64]
             The BIC values from testing this chunk of haplotypes, with shape (p,)
         """
-        # Call JAX JIT-compiled helper and convert result to writable NumPy array
-        bic = _compute_bic_jit(X, yc)
-        return np.array(bic, copy=True)
+        use_jax = False
+        if use_jax:
+            # Call JAX JIT-compiled helper and convert result to writable NumPy array
+            return np.array(_compute_bic_jit(X, yc), copy=True)
+        else:
+            return self._compute_bic(X, yc)
 
     def run(self, X: npt.NDArray[np.float64], y: npt.NDArray[np.float64]) -> AssocResults:
         """

--- a/happler/tree/haplotypes.py
+++ b/happler/tree/haplotypes.py
@@ -195,7 +195,7 @@ class Haplotype:
 
     def _setup_gens_idx(
         self, genotypes: Genotypes, idxs: tuple[int] = None, remove_self: bool = True
-    ) -> tuple[npt.NDArray, np.s_ | tuple[int]]:
+    ) -> tuple[npt.NDArray, npt.NDArray[np.intp]]:
         """
         Helper function to set up the genotypes and indices for transform()
 
@@ -210,22 +210,24 @@ class Haplotype:
         Returns
         -------
         gens : npt.NDArray
-            The genotype data with any self-variants removed if remove_self is True
-        idx : np.s_ or tuple[int]
-            The indices to use for transformation, adjusted if self-variants were removed
+            The genotype data
+        idx : npt.NDArray[np.intp]
+            The variant indices to use for transformation, with any self-variants
+            excluded if remove_self is True
         """
-        idx = np.s_[:]  # alias for all indices
         gens = genotypes.data
-        if remove_self:
-            # first, remove any variants that are already in this haplotype
-            gens = np.delete(gens, self.node_indices, axis=1)
-            # how does the deletion change the desired indices?
-            if idxs is not None:
-                idx = idxs - np.sum(
-                    np.array(self.node_indices)[:, np.newaxis] < idxs, axis=0
-                )
-        elif idxs is not None:
-            idx = idxs
+        # Build candidate indices from all variants or a caller-provided subset.
+        if idxs is None:
+            if remove_self:
+                idx = np.arange(gens.shape[1], dtype=np.intp)
+            else:
+                idx = np.s_[:]
+        else:
+            idx = np.asarray(idxs, dtype=np.intp)
+
+        if remove_self and self.node_indices:
+            # Filter out selected indices that are already in this haplotype to avoid self-matching
+            idx = idx[~np.isin(idx, self.node_indices)]
         return gens, idx
 
     def transform(
@@ -252,7 +254,7 @@ class Haplotype:
             indices. Otherwise, we'll output all of them.
         remove_self : bool, optional
             Whether to first remove any variants that are already in this haplotype
-            using np.delete. This is expensive because it creates a new copy.
+            by filtering indices. This avoids deleting columns from the genotype matrix.
 
         Returns
         -------
@@ -291,7 +293,7 @@ class Haplotype:
             indices. Otherwise, we'll output all of them.
         remove_self : bool, optional
             Whether to first remove any variants that are already in this haplotype
-            using np.delete. This is expensive because it creates a new copy.
+            by filtering indices. This avoids deleting columns from the genotype matrix.
 
         Returns
         -------

--- a/happler/tree/haplotypes.py
+++ b/happler/tree/haplotypes.py
@@ -195,7 +195,7 @@ class Haplotype:
 
     def _setup_gens_idx(
         self, genotypes: Genotypes, idxs: tuple[int] = None, remove_self: bool = True
-    ) -> tuple[npt.NDArray, npt.NDArray[np.intp]]:
+    ) -> tuple[npt.NDArray, np.s_ | tuple[int]]:
         """
         Helper function to set up the genotypes and indices for transform()
 
@@ -210,24 +210,22 @@ class Haplotype:
         Returns
         -------
         gens : npt.NDArray
-            The genotype data
-        idx : npt.NDArray[np.intp]
-            The variant indices to use for transformation, with any self-variants
-            excluded if remove_self is True
+            The genotype data with any self-variants removed if remove_self is True
+        idx : np.s_ or tuple[int]
+            The indices to use for transformation, adjusted if self-variants were removed
         """
+        idx = np.s_[:]  # alias for all indices
         gens = genotypes.data
-        # Build candidate indices from all variants or a caller-provided subset.
-        if idxs is None:
-            if remove_self:
-                idx = np.arange(gens.shape[1], dtype=np.intp)
-            else:
-                idx = np.s_[:]
-        else:
-            idx = np.asarray(idxs, dtype=np.intp)
-
-        if remove_self and self.node_indices:
-            # Filter out selected indices that are already in this haplotype to avoid self-matching
-            idx = idx[~np.isin(idx, self.node_indices)]
+        if remove_self:
+            # first, remove any variants that are already in this haplotype
+            gens = np.delete(gens, self.node_indices, axis=1)
+            # how does the deletion change the desired indices?
+            if idxs is not None:
+                idx = idxs - np.sum(
+                    np.array(self.node_indices)[:, np.newaxis] < idxs, axis=0
+                )
+        elif idxs is not None:
+            idx = idxs
         return gens, idx
 
     def transform(
@@ -254,7 +252,7 @@ class Haplotype:
             indices. Otherwise, we'll output all of them.
         remove_self : bool, optional
             Whether to first remove any variants that are already in this haplotype
-            by filtering indices. This avoids deleting columns from the genotype matrix.
+            using np.delete. This is expensive because it creates a new copy.
 
         Returns
         -------
@@ -293,7 +291,7 @@ class Haplotype:
             indices. Otherwise, we'll output all of them.
         remove_self : bool, optional
             Whether to first remove any variants that are already in this haplotype
-            by filtering indices. This avoids deleting columns from the genotype matrix.
+            using np.delete. This is expensive because it creates a new copy.
 
         Returns
         -------

--- a/happler/tree/haplotypes.py
+++ b/happler/tree/haplotypes.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 import sys
+import logging
 from pathlib import Path
 from logging import Logger
+from functools import partial
 from typing import TextIO, Generator
 from dataclasses import dataclass, field
 
+import jax
 import numpy as np
+import jax.numpy as jnp
 import numpy.typing as npt
 from haptools.data import (
     Extra,
@@ -20,6 +24,42 @@ from haptools.data import (
 from .variant import Variant
 from .tree import Tree, NodeResults
 from .assoc_test import AssocTestSimpleSM
+
+# Configure JAX for 64-bit precision to match NumPy behavior
+logging.getLogger("jax").setLevel(logging.WARNING)
+jax.config.update("jax_enable_x64", True)
+
+
+@partial(jax.jit, static_argnums=(2,))
+def _transform_and_sum_jit(
+    gens_subset: jnp.ndarray,
+    hap_data: jnp.ndarray,
+    allele: int,
+) -> jnp.ndarray:
+    """
+    JIT-compiled function combining haplotype transform and sum operations.
+
+    Fuses ``np.logical_and(gens_subset == allele, hap_data).sum(axis=2)`` into
+    a single compiled kernel, avoiding materialization of the intermediate
+    3D boolean array.
+
+    Parameters
+    ----------
+    gens_subset : jnp.ndarray
+        A subset of the genotype matrix with shape (n_samples, n_variants, ploidy)
+    hap_data : jnp.ndarray
+        The haplotype data with shape (n_samples, 1, ploidy)
+    allele : int
+        The allele value (0 or 1)
+
+    Returns
+    -------
+    jnp.ndarray
+        The summed haplotype matrix with shape (n_samples, n_variants), dtype uint8
+    """
+    return jnp.sum(jnp.logical_and(gens_subset == allele, hap_data), axis=2).astype(
+        jnp.uint8
+    )
 
 
 class Haplotype:
@@ -153,11 +193,47 @@ class Haplotype:
         """
         return tuple(node[0].idx for node in self.nodes)
 
+    def _setup_gens_idx(
+        self, genotypes: Genotypes, idxs: tuple[int] = None, remove_self: bool = True
+    ) -> tuple[npt.NDArray, np.s_ | tuple[int]]:
+        """
+        Helper function to set up the genotypes and indices for transform()
+
+        Parameters
+        ----------
+        genotypes : Genotypes
+            The genotypes which to transform using the current haplotype
+        idxs : tuple[int], optional
+            If specified, we will only output haplotypes for the variants at these
+            indices. Otherwise, we'll output all of them.
+
+        Returns
+        -------
+        gens : npt.NDArray
+            The genotype data with any self-variants removed if remove_self is True
+        idx : np.s_ or tuple[int]
+            The indices to use for transformation, adjusted if self-variants were removed
+        """
+        idx = np.s_[:]  # alias for all indices
+        gens = genotypes.data
+        if remove_self:
+            # first, remove any variants that are already in this haplotype
+            gens = np.delete(gens, self.node_indices, axis=1)
+            # how does the deletion change the desired indices?
+            if idxs is not None:
+                idx = idxs - np.sum(
+                    np.array(self.node_indices)[:, np.newaxis] < idxs, axis=0
+                )
+        elif idxs is not None:
+            idx = idxs
+        return gens, idx
+
     def transform(
         self,
         genotypes: Genotypes,
         allele: int,
         idxs: tuple[int] = None,
+        remove_self: bool = True,
     ) -> npt.NDArray[bool]:
         """
         Transform a genotypes matrix via the current haplotype:
@@ -174,6 +250,9 @@ class Haplotype:
         idxs : tuple[int], optional
             If specified, we will only output haplotypes for the variants at these
             indices. Otherwise, we'll output all of them.
+        remove_self : bool, optional
+            Whether to first remove any variants that are already in this haplotype
+            using np.delete. This is expensive because it creates a new copy.
 
         Returns
         -------
@@ -181,21 +260,50 @@ class Haplotype:
             A 3D haplotype matrix similar to the genotype matrix but with haplotypes
             instead of variants in the columns. It will have the same shape except that
             the number of columns (second dimension) will have decreased by the number
-            of variants in this haplotype.
+            of variants in this haplotype if remove_self is True
         """
-        # first, remove any variants that are already in this haplotype using np.delete
-        # TODO: consider moving this outside of this function
-        gens = np.delete(genotypes.data, self.node_indices, axis=1)
-        # how does the deletion change the desired indices?
-        if idxs is not None:
-            idxs -= np.sum(np.array(self.node_indices)[:, np.newaxis] < idxs, axis=0)
-        else:
-            # alias for all of the indices
-            idxs = np.s_[:]
-        # add extra axes to match shape of gens
-        hap_data = self.data[:, np.newaxis]
+        gens, idx = self._setup_gens_idx(genotypes, idxs, remove_self)
         # use np.logical_and to superimpose the current haplotype onto the GT matrix
-        return np.logical_and(gens[:, idxs] == allele, hap_data)
+        return np.logical_and(gens[:, idx] == allele, self.data[:, np.newaxis])
+
+    def transform_and_sum(
+        self,
+        genotypes: Genotypes,
+        allele: int,
+        idxs: tuple[int] = None,
+        remove_self: bool = True,
+    ) -> npt.NDArray[np.uint8]:
+        """
+        Transform a genotypes matrix and sum along the ploidy axis using JAX JIT.
+
+        Combines :py:meth:`~.Haplotype.transform` and ``.sum(axis=2)`` into a
+        single JAX JIT-compiled operation, avoiding materialization of the
+        intermediate 3D boolean array.
+
+        Parameters
+        ----------
+        genotypes : Genotypes
+            The genotypes which to transform using the current haplotype
+        allele : int
+            The allele (either 0 or 1) of the SNPs we're adding
+        idxs : tuple[int], optional
+            If specified, we will only output haplotypes for the variants at these
+            indices. Otherwise, we'll output all of them.
+        remove_self : bool, optional
+            Whether to first remove any variants that are already in this haplotype
+            using np.delete. This is expensive because it creates a new copy.
+
+        Returns
+        -------
+        npt.NDArray[np.uint8]
+            A 2D matrix with shape (num_samples, num_variants) where each entry is
+            the count of chromosomes carrying the haplotype (0, 1, or 2)
+        """
+        gens, idx = self._setup_gens_idx(genotypes, idxs, remove_self)
+        # use JAX JIT to fuse the logical_and + sum operations
+        return np.asarray(
+            _transform_and_sum_jit(gens[:, idx], self.data[:, np.newaxis], int(allele))
+        )
 
 
 @dataclass

--- a/happler/tree/tree_builder.py
+++ b/happler/tree/tree_builder.py
@@ -208,32 +208,6 @@ class TreeBuilder:
             f"Pruned {count} leaves with LD > {self.ld_prune_thresh} with their siblings"
         )
 
-    def maf_mask(
-        self,
-        hap_matrix: npt.NDArray[np.bool_],
-    ) -> npt.NDArray:
-        """
-        Check the minor allele frequency of each haplotype in the provided hap matrix
-
-        Parameters
-        ----------
-        hap_matrix: npt.NDArray[np.bool_]
-            An array of haplotype "genotypes" of shape: num_samples x num_haplotypes
-
-        Returns
-        -------
-            An integer mask denoting the indices of the haplotypes that passed the
-            MAF threshold
-        """
-        if self.maf is None:
-            return np.arange(hap_matrix.shape[1])
-        num_strands = 2 * hap_matrix.shape[0]
-        # TODO: make this work for multi-allelic variants, too?
-        ref_af = hap_matrix.sum(axis=(0, 2)) / num_strands
-        maf = np.array([ref_af, 1 - ref_af]).min(axis=0)
-        common_variants = maf >= self.maf
-        return np.nonzero(common_variants)[0]
-
     def _find_split_flexible(
         self, parent: Haplotype, parent_res: NodeResults = None
     ) -> tuple[Variant, np.void]:
@@ -260,18 +234,24 @@ class TreeBuilder:
         alleles = (0, 1)
         for allele in alleles:
             # step 1: transform the GT matrix into a matrix of common haplotypes
-            hap_matrix = parent.transform(self.gens, allele)
-            maf_mask = self.maf_mask(hap_matrix)
-            if len(maf_mask) != hap_matrix.shape[1]:
-                self.log.debug(
-                    f"Considering {len(maf_mask)} variants for allele {allele}"
-                )
-            hap_matrix = hap_matrix[:, maf_mask]
-            if hap_matrix.shape[1] == 0:
+            hap_mat_sum = parent.transform_and_sum(self.gens, allele)
+            # step 1.5: filter out any haplotypes with low MAF
+            if self.maf is not None:
+                ref_af = hap_mat_sum.sum(axis=0) / hap_mat_sum.shape[0] / 2
+                maf = np.minimum(ref_af, 1 - ref_af)
+                maf_mask = np.nonzero(maf >= self.maf)[0]
+                if len(maf_mask) < hap_mat_sum.shape[1]:
+                    self.log.debug(
+                        f"Considering {len(maf_mask)} variants for allele {allele}"
+                    )
+                    hap_mat_sum = hap_mat_sum[:, maf_mask]
+            else:
+                maf_mask = np.arange(hap_mat_sum.shape[1])
+            if hap_mat_sum.shape[1] == 0:
                 # if there weren't any genotypes left, just return None
+                self.log.debug(f"No variants passed --hap-maf for allele {allele}")
                 final_to_return.append((None, allele, None))
                 continue
-            hap_mat_sum = hap_matrix.sum(axis=2, dtype=np.uint8)
             parent_corr = None
             # step 2: run all association tests on all of the haplotypes
             if isinstance(self.method, AssocTestSimpleSMTScore) and not (
@@ -398,22 +378,24 @@ class TreeBuilder:
         alleles = (0, 1)
         for allele in alleles:
             # step 1: transform the GT matrix into a matrix of common haplotypes
-            hap_matrix = parent.transform(self.gens, allele)
-            maf_mask[allele] = self.maf_mask(hap_matrix)
-            if len(maf_mask[allele]) != hap_matrix.shape[1]:
-                self.log.debug(
-                    f"Considering {len(maf_mask[allele])} variants for allele {allele}"
-                )
-            # check if we actually need to filter at all
-            # If not, it's better to avoid it bc this can create a copy of the array!
-            if maf_mask[allele].shape[0] == 0:
+            hap_mat_sum = parent.transform_and_sum(self.gens, allele)
+            # step 1.5: filter out any haplotypes with low MAF
+            if self.maf is not None:
+                ref_af = hap_mat_sum.sum(axis=0) / hap_mat_sum.shape[0] / 2
+                maf = np.minimum(ref_af, 1 - ref_af)
+                maf_mask[allele] = np.nonzero(maf >= self.maf)[0]
+                if len(maf_mask[allele]) < hap_mat_sum.shape[1]:
+                    self.log.debug(
+                        f"Considering {len(maf_mask[allele])} variants for allele {allele}"
+                    )
+                    hap_mat_sum = hap_mat_sum[:, maf_mask[allele]]
+            else:
+                maf_mask[allele] = np.arange(hap_mat_sum.shape[1])
+            if hap_mat_sum.shape[1] == 0:
                 # if there weren't any genotypes left, just return None
+                self.log.debug(f"No variants passed --hap-maf for allele {allele}")
                 final_to_return.append((None, allele, None))
                 continue
-            elif maf_mask[allele].shape[0] < hap_matrix.shape[1]:
-                hap_mat_sum = hap_matrix[:, maf_mask[allele]].sum(axis=2, dtype=np.uint8)
-            else:
-                hap_mat_sum = hap_matrix.sum(axis=2, dtype=np.uint8)
             parent_corr[allele] = None
             # step 2: run all association tests on all of the haplotypes
             if isinstance(self.method, AssocTestSimpleSMTScore) and not (

--- a/happler/tree/tree_builder.py
+++ b/happler/tree/tree_builder.py
@@ -439,6 +439,7 @@ class TreeBuilder:
                 maf_mask[int(not best_allele)], maf_mask[best_allele][best_var_idx]
             ),
         }
+        best_res_idx = dict(sorted(best_res_idx.items()))
         num_tests = len(parent.nodes) + 1
         # step 4: find the index of the best variant within the genotype matrix
         # We need to account for the rare variants that were masked out and indices

--- a/happler/tree/tree_builder.py
+++ b/happler/tree/tree_builder.py
@@ -439,7 +439,6 @@ class TreeBuilder:
                 maf_mask[int(not best_allele)], maf_mask[best_allele][best_var_idx]
             ),
         }
-        best_res_idx = dict(sorted(best_res_idx.items()))
         num_tests = len(parent.nodes) + 1
         # step 4: find the index of the best variant within the genotype matrix
         # We need to account for the rare variants that were masked out and indices

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -17,6 +17,8 @@ from happler.tree import (
     NodeResultsExtra,
 )
 
+from happler.tree.haplotypes import _transform_and_sum_jit
+
 DATADIR = Path(__file__).parent.joinpath("data")
 
 
@@ -313,6 +315,107 @@ def test_haplotypes_write():
 
     # remove the file
     os.remove("test_write.haps")
+
+
+def _make_haplotype(gts_data, variant_idx, allele):
+    """Helper: create a single-node Haplotype from a raw genotype array."""
+    variant = Variant(idx=variant_idx, id=f"SNP{variant_idx}", pos=variant_idx + 1)
+    variant_gts = gts_data[:, variant_idx, :] == allele
+    return Haplotype.from_node(variant, allele, variant_gts)
+
+
+def test_transform_and_sum_matches_transform():
+    """
+    transform_and_sum should produce results identical to transform(...).sum(axis=2)
+    for every combination of allele (0, 1), remove_self (True, False), and idxs.
+    """
+    rng = np.random.default_rng(42)
+    n_samples, n_variants, ploidy = 20, 5, 2
+    gts_data = rng.integers(0, 2, size=(n_samples, n_variants, ploidy)).astype(np.bool_)
+
+    # Build a minimal Genotypes-like object
+    class FakeGenotypes:
+        pass
+
+    fake_gens = FakeGenotypes()
+    fake_gens.data = gts_data
+
+    for allele in (0, 1):
+        for variant_idx in range(n_variants):
+            hap = _make_haplotype(gts_data, variant_idx, allele)
+
+            # --- remove_self=True, no idxs ---
+            expected = hap.transform(fake_gens, allele, remove_self=True).sum(axis=2)
+            actual = hap.transform_and_sum(fake_gens, allele, remove_self=True)
+            np.testing.assert_array_equal(
+                actual,
+                expected,
+                err_msg=f"allele={allele}, variant_idx={variant_idx}, remove_self=True",
+            )
+
+            # --- remove_self=False, no idxs ---
+            expected = hap.transform(fake_gens, allele, remove_self=False).sum(axis=2)
+            actual = hap.transform_and_sum(fake_gens, allele, remove_self=False)
+            np.testing.assert_array_equal(
+                actual,
+                expected,
+                err_msg=f"allele={allele}, variant_idx={variant_idx}, remove_self=False",
+            )
+
+            # --- remove_self=False, explicit idxs (exclude current variant) ---
+            other_idxs = np.array([i for i in range(n_variants) if i != variant_idx])
+            expected = hap.transform(
+                fake_gens, allele, idxs=other_idxs, remove_self=False
+            ).sum(axis=2)
+            actual = hap.transform_and_sum(
+                fake_gens, allele, idxs=other_idxs, remove_self=False
+            )
+            np.testing.assert_array_equal(
+                actual,
+                expected,
+                err_msg=(
+                    f"allele={allele}, variant_idx={variant_idx}, "
+                    "remove_self=False, explicit idxs"
+                ),
+            )
+
+
+def test_transform_and_sum_jit_directly():
+    """
+    The raw JAX _transform_and_sum_jit helper should match the NumPy reference
+    np.logical_and(gens == allele, hap_data).sum(axis=2).
+    """
+    import jax.numpy as jnp
+
+    rng = np.random.default_rng(7)
+    n_samples, n_variants, ploidy = 15, 4, 2
+    gts = rng.integers(0, 2, size=(n_samples, n_variants, ploidy)).astype(np.bool_)
+    hap = rng.integers(0, 2, size=(n_samples, 1, ploidy)).astype(np.bool_)
+
+    for allele in (0, 1):
+        expected = np.logical_and(gts == allele, hap).sum(axis=2).astype(np.uint8)
+        result = np.asarray(_transform_and_sum_jit(gts, hap, allele))
+        np.testing.assert_array_equal(
+            result, expected, err_msg=f"_transform_and_sum_jit failed for allele={allele}"
+        )
+
+
+def test_transform_and_sum_dtype():
+    """transform_and_sum should always return a uint8 NumPy array."""
+    rng = np.random.default_rng(0)
+    n_samples, n_variants, ploidy = 10, 3, 2
+    gts_data = rng.integers(0, 2, size=(n_samples, n_variants, ploidy)).astype(np.bool_)
+
+    class FakeGenotypes:
+        pass
+
+    fake_gens = FakeGenotypes()
+    fake_gens.data = gts_data
+
+    hap = _make_haplotype(gts_data, 0, 0)
+    result = hap.transform_and_sum(fake_gens, 0)
+    assert isinstance(result, np.ndarray), "result should be a NumPy array"
+    assert result.dtype == np.uint8, f"expected uint8, got {result.dtype}"
 
 
 def test_simple_assoc():


### PR DESCRIPTION
We discovered in #55  that using JAX for the two most time-consuming operations (transforming and summing across the genotypes) can cut our runtime in half